### PR TITLE
Make role more flexible, build or pkg install, RH support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 ---
 sudo: required
-dist: xenial
+dist: trusty
 
 language: python
 python: "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,11 +62,11 @@ script:
   - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
 
   # Run the role/playbook with ansible-playbook.
-  - ansible-playbook -i tests/inventory tests/$SITE --connection=local --sudo
+  - ansible-playbook -i tests/inventory tests/$SITE --connection=local --become
 
   # Run the role/playbook again, checking to make sure it's idempotent.
   - >
-    ansible-playbook -i tests/inventory tests/$SITE --connection=local --sudo
+    ansible-playbook -i tests/inventory tests/$SITE --connection=local --become
     | grep -q 'changed=0.*failed=0'
     && (echo 'Idempotence test: pass' && exit 0)
     || (echo 'Idempotence test: fail' && exit 1)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 ---
 sudo: required
-dist: trusty
+dist: xenial
 
 language: python
 python: "2.7"
@@ -11,11 +11,6 @@ env:
   - SITE=test.yml ENCRYPTION='--no-encryption' ANSIBLE_VERSION=2.0.0.2
   - SITE=test.yml ENCRYPTION='--no-encryption' ANSIBLE_VERSION=2.0.0.1
   - SITE=test.yml ENCRYPTION='--no-encryption' ANSIBLE_VERSION=2.0.0.0
-  - SITE=test.yml ENCRYPTION='--no-encryption' ANSIBLE_VERSION=1.9.4
-  - SITE=test.yml ENCRYPTION='--no-encryption' ANSIBLE_VERSION=1.9.3
-  - SITE=test.yml ENCRYPTION='--no-encryption' ANSIBLE_VERSION=1.9.2
-  - SITE=test.yml ENCRYPTION='--no-encryption' ANSIBLE_VERSION=1.9.1
-  - SITE=test.yml ENCRYPTION='--no-encryption' ANSIBLE_VERSION=1.9.0.1
 
 #  - SITE=test-gpg.yml  ENCRYPTION='91F29F5F' PASSPHRASE='ThisShouldBeYourPersonalUniquePassphrase' ANSIBLE_VERSION=latest
 #  - SITE=test-gpg.yml  ENCRYPTION='91F29F5F' PASSPHRASE='ThisShouldBeYourPersonalUniquePassphrase' ANSIBLE_VERSION=2.0.1.0

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ MIT / BSD
 
 # TODO
 
- - Fix task "Add servers to known hosts. Use 'ssh-keyscan -t rsa example.org' to get server key" fail if .ssh/ not exist
+ - ~~Fix task "Add servers to known hosts. Use 'ssh-keyscan -t rsa example.org' to get server key" fail if .ssh/ not exist~~
  - Fix example
  - not build duplicity, use pkges (build require many building depends)
  - add support CentOS

--- a/README.md
+++ b/README.md
@@ -169,8 +169,7 @@ MIT / BSD
 
  - ~~Fix task "Add servers to known hosts. Use 'ssh-keyscan -t rsa example.org' to get server key" fail if .ssh/ not exist~~
  - ~~Fix example~~
- - not build duplicity, use pkges (build require many building depends)
+ - ~~not build duplicity, use pkges (build require many building depends)~~
  - ~~add support CentOS~~
- - add more tags
- - remove custome sh (install only set tag)
+ - ~~remove custome sh (install only set var)~~
  - Fix reinstall and install another version, now not rewrited file /usr/local/bin/duplicity and not removed pip uninstal duplicity

--- a/README.md
+++ b/README.md
@@ -22,52 +22,56 @@ $ ansible-galaxy install tschifftner.duplicity
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
+```yaml
     - hosts: webservers
-          vars:
-            # duplictity
-            duplicity_known_hosts:
-              - host: 'example.org'
-                key: 'example.org ssh-rsa AAAAB3NzaC...+PwAK+MPw=='
-                state: present
-        
-            duplicity_config_vars:
-              FTP_SERVER: 'sftp://username@example.org/my/folder/'
-              FTP_PASSWORD: '*******'
-              DEFAULT_PARAMS: '--verbosity info --exclude-device-files --exclude-other-filesystems --exclude-if-present .duplicity-ignore'
-        
-            duplicity_cronjobs:
-              - name: 'Cleanup older than 2 months'
-                user: root
-                group: root
-                source: /etc/duplicity/duplicity.conf
-                hour: 4
-                minute: 10
-                command: >
-                  duplicity remove-older-than 2M --force --extra-clean $FTP_SERVER;
-                  duplicity cleanup --force $FTP_SERVER
-        
-              - name: 'Backup /var/www'
-                user: root
-                group: root
-                hour: 5
-                minute: 21
-                source: /etc/duplicity/duplicity.conf
-                command: duplicity $DEFAULT_PARAMS --include /var/www --full-if-older-than 1M --exclude '**' / $FTP_SERVER
+      vars:
+        # duplictity
+        duplicity_known_hosts:
+          - host: 'example.org'
+            key: 'example.org ssh-rsa AAAAB3NzaC...+PwAK+MPw=='
+            state: present
     
-          roles:
+        duplicity_config_vars:
+          FTP_SERVER: 'sftp://username@example.org/my/folder/'
+          FTP_PASSWORD: '*******'
+          DEFAULT_PARAMS: '--verbosity info --exclude-device-files --exclude-other-filesystems --exclude-if-present .duplicity-ignore'
+    
+        duplicity_cronjobs:
+          - name: 'Cleanup older than 2 months'
+            user: root
+            group: root
+            source: /etc/duplicity/duplicity.conf
+            hour: 4
+            minute: 10
+            command: >
+              duplicity remove-older-than 2M --force --extra-clean $FTP_SERVER;
+              duplicity cleanup --force $FTP_SERVER
+    
+          - name: 'Backup /var/www'
+            user: root
+            group: root
+            hour: 5
+            minute: 21
+            source: /etc/duplicity/duplicity.conf
+            command: duplicity $DEFAULT_PARAMS --include /var/www --full-if-older-than 1M --exclude '**' / $FTP_SERVER
+
+      roles:
              - { role: tschifftner.duplicity }
+```
 
 It's recommended to put all vars in an external file.
-    
+
+```yaml
     - hosts: webservers
       vars_files:
         - duplicity-settings.yml
     
       roles:
          - { role: tschifftner.duplicity }
+```
 
 ## Tips
- - Use ```ssh-keyscan -t rsa example.org``` to get ssh-key for a server (used in duplicity_known_hosts variable)
+ - Use `ssh-keyscan -t rsa example.org` to get ssh-key for a server (used in duplicity_known_hosts variable)
  - Its possible to write cronjobs in multiple lines. But this causes failure in idempotence! For example:
  
 ```
@@ -79,7 +83,7 @@ It's recommended to put all vars in an external file.
 This will always result in changed!      
       
 ### Duplicity variables
-```
+```yaml
 duplicity_config_vars:
   SERVER: 'ftp://username@ftp.example.com/backups/'
   PASSPHRASE: 'YourSecretPassphrase'
@@ -167,7 +171,7 @@ MIT / BSD
 # TODO
 
  - ~~Fix task "Add servers to known hosts. Use 'ssh-keyscan -t rsa example.org' to get server key" fail if .ssh/ not exist~~
- - Fix example
+ - ~~Fix example~~
  - not build duplicity, use pkges (build require many building depends)
  - add support CentOS
  - add more tags

--- a/README.md
+++ b/README.md
@@ -174,3 +174,4 @@ MIT / BSD
  - add support CentOS
  - add more tags
  - remove custome sh (install only set tag)
+ - Fix reinstall and install another version, now not rewrited file /usr/local/bin/duplicity and not removed pip uninstal duplicity

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ gpg --output FB37DF3B.private.asc --armor --export-secret-key FB37DF3B
 
 To mark hosts as known hosts
       
-```
+```yaml
 duplicity_known_hosts:
   - host: 'ftp.example.com'
     key: 'ftp.example.com ssh-rsa AAAAB3NzaC1yc2[...]+MPw=='

--- a/README.md
+++ b/README.md
@@ -138,7 +138,14 @@ duplicity_known_hosts:
   - host: 'ftp.example.com'
     key: 'ftp.example.com ssh-rsa AAAAB3NzaC1yc2[...]+MPw=='
     state: 'present'
-```          
+```
+
+If you are sure that your system supports, it is possible to use ecdsa and ed25519 keys.
+
+```
+ssh-keyscan -t ecdsa ftp.example.com
+ssh-keyscan -t ed25519 ftp.example.com
+```
 
 ## Supported OS
 

--- a/README.md
+++ b/README.md
@@ -153,12 +153,10 @@ ssh-keyscan -t ed25519 ftp.example.com
 
 ## Supported OS
 
-Ansible          | Debian Jessie    | Ubuntu 14.04    | Ubuntu 12.04
-:--------------: | :--------------: | :-------------: | :-------------: 
-1.9              | Yes              | Yes             | Yes
-2.0.1*           | Yes              | Yes             | Yes
-
-*) 2.0.0.0, 2.0.0.1, 2.0.0.2 are not supported!
+Ansible          | Debian Jessie    | Ubuntu 16.04    | Ubuntu 14.04    | Ubuntu 12.04
+:--------------: | :--------------: | :-------------: | :-------------: | :-------------: 
+1.9              | Yes              | Yes             | Yes             | Yes
+2.0              | Yes              | Yes             | Yes             | Yes
      
 ## License
 

--- a/README.md
+++ b/README.md
@@ -167,9 +167,4 @@ MIT / BSD
 
 # TODO
 
- - ~~Fix task "Add servers to known hosts. Use 'ssh-keyscan -t rsa example.org' to get server key" fail if .ssh/ not exist~~
- - ~~Fix example~~
- - ~~not build duplicity, use pkges (build require many building depends)~~
- - ~~add support CentOS~~
- - ~~remove custome sh (install only set var)~~
  - Fix reinstall and install another version, now not rewrited file /usr/local/bin/duplicity and not removed pip uninstal duplicity

--- a/README.md
+++ b/README.md
@@ -156,3 +156,12 @@ MIT / BSD
 ## Author Information
 
  - Tobias Schifftner, @tschifftner
+
+# TODO
+
+ - Fix task "Add servers to known hosts. Use 'ssh-keyscan -t rsa example.org' to get server key" fail if .ssh/ not exist
+ - Fix example
+ - not build duplicity, use pkges (build require many building depends)
+ - add support CentOS
+ - add more tags
+ - remove custome sh (install only set tag)

--- a/README.md
+++ b/README.md
@@ -153,10 +153,9 @@ ssh-keyscan -t ed25519 ftp.example.com
 
 ## Supported OS
 
-Ansible          | Debian Jessie    | Ubuntu 16.04    | Ubuntu 14.04    | Ubuntu 12.04
-:--------------: | :--------------: | :-------------: | :-------------: | :-------------: 
-1.9              | Yes              | Yes             | Yes             | Yes
-2.0              | Yes              | Yes             | Yes             | Yes
+Ansible          | Debian Jessie    | CentOS 7        | Ubuntu 16.04    | Ubuntu 14.04    | Ubuntu 12.04    | Fedora 23
+:--------------: | :--------------: | :-------------: | :-------------: | :-------------: | :-------------: | :-------------:
+2.0              | Yes              | Yes             | Yes             | Yes             | Yes             | Yes
      
 ## License
 
@@ -171,7 +170,7 @@ MIT / BSD
  - ~~Fix task "Add servers to known hosts. Use 'ssh-keyscan -t rsa example.org' to get server key" fail if .ssh/ not exist~~
  - ~~Fix example~~
  - not build duplicity, use pkges (build require many building depends)
- - add support CentOS
+ - ~~add support CentOS~~
  - add more tags
  - remove custome sh (install only set tag)
  - Fix reinstall and install another version, now not rewrited file /usr/local/bin/duplicity and not removed pip uninstal duplicity

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,3 +35,6 @@ duplicity_gpg_private_keys: []
 # If you need global reconfigure dash to bash add duplicity_dash_to_bash var for you host
 
 # If you need duplicity_script.sh set duplicity_tools var for you host
+
+# Install type, pkg - install atp or rpm pkg, build - download tar.gz and install (python setup.py install)
+duplicity_install_type: pkg

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,3 +31,5 @@ duplicity_exclude_list:
 duplicity_gpg_public_keys: []
 duplicity_gpg_ownertrusts: []
 duplicity_gpg_private_keys: []
+
+# If you need global reconfigure dash to bash add duplicity_dash_to_bash var for you host

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,3 +33,5 @@ duplicity_gpg_ownertrusts: []
 duplicity_gpg_private_keys: []
 
 # If you need global reconfigure dash to bash add duplicity_dash_to_bash var for you host
+
+# If you need duplicity_script.sh set duplicity_tools var for you host

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-duplicity_version: "0.7.07.1"
+duplicity_version: "0.7.06"
 
 duplicity_backup_scripts: []
 #- { src: duplicity_script.sh, dest: /usr/local/sbin/duplicity_script, backup: yes, user: root, group: root, mode: 0500 }

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-duplicity_version: "0.7.06"
+duplicity_version: "0.7.07.1"
 
 duplicity_backup_scripts: []
 #- { src: duplicity_script.sh, dest: /usr/local/sbin/duplicity_script, backup: yes, user: root, group: root, mode: 0500 }

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   description: Installs duplicity from source and handles backup tasks on Debian/Ubuntu linux servers.
   company: ambimax® GmbH
   license: MIT
-  min_ansible_version: 1.9
+  min_ansible_version: 2.0
   platforms:
   - name: Debian
     versions:
@@ -15,6 +15,12 @@ galaxy_info:
     versions:
     - trusty
     - xenial
+  - name: EL
+    versions:
+    - 7
+  - name: Fedora
+    versions:
+    - 23
   galaxy_tags:
     - debian
     - ubuntu

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,6 +14,7 @@ galaxy_info:
   - name: Ubuntu
     versions:
     - trusty
+    - xenial
   galaxy_tags:
     - debian
     - ubuntu

--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -1,10 +1,4 @@
 ---
-- name: 'Install build pkg dependencies'
-  package:
-    pkg: "{{ item }}"
-    state: present
-  with_items: '{{duplicity_build_dependencies}}'
-
 - name: 'Create duplicity dir'
   file:
     path: "{{ duplicity_workspace }}/duplicity"

--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -1,0 +1,28 @@
+---
+- name: 'Install build pkg dependencies'
+  package:
+    pkg: "{{ item }}"
+    state: present
+  with_items: '{{duplicity_build_dependencies}}'
+
+- name: 'Create duplicity dir'
+  file:
+    path: "{{ duplicity_workspace }}/duplicity"
+    state: directory
+
+- name: 'Download duplicity.tar.gz'
+  get_url:
+    url: "{{ duplicity_download_url }}"
+    dest: "{{ duplicity_workspace }}/{{ duplicity_version }}.tar.gz"
+
+- name: 'Unarchive duplicity.tar.gz'
+  unarchive:
+    src: "{{ duplicity_workspace }}/{{ duplicity_version }}.tar.gz"
+    dest: "{{ duplicity_workspace }}"
+    copy: no
+
+- name: 'Install duplicity'
+  shell: python setup.py install
+  args:
+    chdir: "{{ duplicity_workspace }}/duplicity-{{ duplicity_version }}"
+    creates: "{{ duplicity_bin }}"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -4,7 +4,7 @@
     dest: /bin/sh
     src: bash
     state: link
-  when: '{{duplicity_dash_to_bash is defined}}'
+  when: duplicity_dash_to_bash is defined
 
 - name: 'Ensure /var/log/duplicity.log exists and is writable'
   file:
@@ -47,7 +47,7 @@
     mode: '0700'
     state: directory
   with_items: '{{duplicity_known_hosts}}'
-  when: '{{duplicity_known_hosts is defined and duplicity_known_hosts|length}}'
+  when: duplicity_known_hosts is defined and duplicity_known_hosts|length
 
 - name: "Add servers to known hosts. Use 'ssh-keyscan -t rsa example.org' to get server key"
   known_hosts:
@@ -56,7 +56,7 @@
     state: "{{ item.state }}"
     path: /root/.ssh/known_hosts
   with_items: '{{duplicity_known_hosts}}'
-  when: '{{duplicity_known_hosts is defined and duplicity_known_hosts|length}}'
+  when: duplicity_known_hosts is defined and duplicity_known_hosts|length
 
 - name: 'Add environment variables (NOT SECURE! Visible to ALL users)'
   no_log: true

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -106,7 +106,7 @@
     state: "{{ item.state | default('present') }}"
     cron_file: "{{ item.cron_file | default('duplicity') }}"
     special_time: "{{ item.special_time | default(omit) }}"
-  when: '{{(item.command is defined and item.command != '') or (item.state == 'absent')}}'
+  when: (item.command is defined and item.command != '') or (item.state == 'absent')
   with_items: '{{duplicity_cronjobs}}'
 
 - name: 'Set logrotate'

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -38,6 +38,16 @@
     group: root
     mode: '0550'
 
+- name: "Ensure /root/.ssh exists and is protected" 
+  file:
+    path: /root/.ssh
+    owner: root
+    group: root
+    mode: '0700'
+    state: directory
+  with_items: duplicity_known_hosts
+  when: duplicity_known_hosts is defined and duplicity_known_hosts|length
+
 - name: "Add servers to known hosts. Use 'ssh-keyscan -t rsa example.org' to get server key"
   known_hosts:
     host: "{{ item.host }}"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -38,6 +38,7 @@
     owner: root
     group: root
     mode: '0550'
+  when: duplicity_tools is defined
 
 - name: "Ensure /root/.ssh exists and is protected" 
   file:
@@ -90,6 +91,7 @@
     owner: "{{ item.owner }}"
     group: "{{ item.group }}"
     mode: "{{ item.mode | default(0550) }}"
+  when: duplicity_tools is defined
   with_items: '{{duplicity_backup_scripts}}'
 
 - name: 'Add custom crontab jobs for duplicity'

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -40,7 +40,7 @@
     mode: '0550'
   when: duplicity_tools is defined
 
-- name: "Ensure /root/.ssh exists and is protected" 
+- name: "Ensure /root/.ssh exists and is protected"
   file:
     path: /root/.ssh
     owner: root

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -4,7 +4,7 @@
     dest: /bin/sh
     src: bash
     state: link
-  when: duplicity_dash_to_bash is defined
+  when: '{{duplicity_dash_to_bash is defined}}'
 
 - name: 'Ensure /var/log/duplicity.log exists and is writable'
   file:
@@ -46,8 +46,8 @@
     group: root
     mode: '0700'
     state: directory
-  with_items: duplicity_known_hosts
-  when: duplicity_known_hosts is defined and duplicity_known_hosts|length
+  with_items: '{{duplicity_known_hosts}}'
+  when: '{{duplicity_known_hosts is defined and duplicity_known_hosts|length}}'
 
 - name: "Add servers to known hosts. Use 'ssh-keyscan -t rsa example.org' to get server key"
   known_hosts:
@@ -55,8 +55,8 @@
     key: "{{ item.key }}"
     state: "{{ item.state }}"
     path: /root/.ssh/known_hosts
-  with_items: duplicity_known_hosts
-  when: duplicity_known_hosts is defined and duplicity_known_hosts|length
+  with_items: '{{duplicity_known_hosts}}'
+  when: '{{duplicity_known_hosts is defined and duplicity_known_hosts|length}}'
 
 - name: 'Add environment variables (NOT SECURE! Visible to ALL users)'
   no_log: true
@@ -67,7 +67,7 @@
     owner: root
     group: root
     mode: '0644'
-  with_dict: duplicity_environment_vars
+  with_dict: '{{duplicity_environment_vars}}'
 
 - name: 'Add duplicity config'
   no_log: true
@@ -80,7 +80,7 @@
     mode: '00640'
     create: yes
     state: present
-  with_dict: duplicity_config_vars
+  with_dict: '{{duplicity_config_vars}}'
 
 - name: 'Add custom duplicity scripts'
   template:
@@ -90,7 +90,7 @@
     owner: "{{ item.owner }}"
     group: "{{ item.group }}"
     mode: "{{ item.mode | default(0550) }}"
-  with_items: duplicity_backup_scripts
+  with_items: '{{duplicity_backup_scripts}}'
 
 - name: 'Add custom crontab jobs for duplicity'
   cron:
@@ -106,8 +106,8 @@
     state: "{{ item.state | default('present') }}"
     cron_file: "{{ item.cron_file | default('duplicity') }}"
     special_time: "{{ item.special_time | default(omit) }}"
-  when: (item.command is defined and item.command != '') or (item.state == 'absent')
-  with_items: duplicity_cronjobs
+  when: '{{(item.command is defined and item.command != '') or (item.state == 'absent')}}'
+  with_items: '{{duplicity_cronjobs}}'
 
 - name: 'Set logrotate'
   copy:

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -4,6 +4,7 @@
     dest: /bin/sh
     src: bash
     state: link
+  when: duplicity_dash_to_bash is defined
 
 - name: 'Ensure /var/log/duplicity.log exists and is writable'
   file:

--- a/tasks/gpg.yml
+++ b/tasks/gpg.yml
@@ -11,17 +11,17 @@
   shell: "echo '{{ lookup('file', item) }}' | gpg --import && touch {{ duplicity_lock_directory }}/{{ item | basename }}"
   args:
     creates: "{{ duplicity_lock_directory }}/{{ item | basename }}"
-  with_items: duplicity_gpg_public_keys
+  with_items: '{{duplicity_gpg_public_keys}}'
 
 - name: import ownertrusts
   shell: "echo '{{ lookup('file', item) }}' | gpg --import-ownertrust && touch {{ duplicity_lock_directory }}/{{ item | basename }}"
   args:
     creates: "{{ duplicity_lock_directory }}/{{ item | basename }}"
   notify: update trustdb
-  with_items: duplicity_gpg_ownertrusts
+  with_items: '{{duplicity_gpg_ownertrusts}}'
 
 - name: import private keys
   shell: "echo '{{ lookup('file', item) }}' | gpg --allow-secret-key-import --import && touch {{ duplicity_lock_directory }}/{{ item | basename }}"
   args:
     creates: "{{ duplicity_lock_directory }}/{{ item | basename }}"
-  with_items: duplicity_gpg_private_keys
+  with_items: '{{duplicity_gpg_private_keys}}'

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -38,6 +38,3 @@
   args:
     chdir: "{{ duplicity_workspace }}/duplicity-{{ duplicity_version }}"
     creates: /usr/local/bin/duplicity
-
-- name: 'Fail if duplicity does not exist'
-  shell: duplicity --version

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -22,6 +22,13 @@
   with_items: '{{duplicity_pkg_dependencies}}'
   when: duplicity_install_type == "pkg"
 
+- name: 'Install build pkg dependencies'
+  package:
+    pkg: "{{ item }}"
+    state: present
+  with_items: '{{duplicity_build_dependencies}}'
+  when: duplicity_install_type == "build"
+
 - name: 'Install pip packages'
   pip:
     name: "{{ item.name }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -20,31 +20,10 @@
     pkg: "{{ item }}"
     state: present
   with_items: '{{duplicity_pkg_dependencies}}'
+  when: duplicity_install_type == "pkg"
 
 - name: 'Install pip packages'
   pip:
     name: "{{ item.name }}"
     state: "{{ item.state}}"
   with_items: '{{duplicity_pip_packages}}'
-
-- name: 'Create duplicity dir'
-  file:
-    path: "{{ duplicity_workspace }}/duplicity"
-    state: directory
-
-- name: 'Download duplicity.tar.gz'
-  get_url:
-    url: "{{ duplicity_download_url }}"
-    dest: "{{ duplicity_workspace }}/{{ duplicity_version }}.tar.gz"
-
-- name: 'Unarchive duplicity.tar.gz'
-  unarchive:
-    src: "{{ duplicity_workspace }}/{{ duplicity_version }}.tar.gz"
-    dest: "{{ duplicity_workspace }}"
-    copy: no
-
-- name: 'Install duplicity'
-  shell: python setup.py install
-  args:
-    chdir: "{{ duplicity_workspace }}/duplicity-{{ duplicity_version }}"
-    creates: "{{ duplicity_bin }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -9,13 +9,13 @@
   apt:
     pkg: "{{ item }}"
     state: present
-  with_items: duplicity_apt_dependencies
+  with_items: '{{duplicity_apt_dependencies}}'
 
 - name: 'Install pip packages'
   pip:
     name: "{{ item.name }}"
     state: "{{ item.state}}"
-  with_items: duplicity_pip_packages
+  with_items: '{{duplicity_pip_packages}}'
 
 - name: 'Create duplicity dir'
   file:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -6,9 +6,9 @@
     cache_valid_time: 86400
   when: ansible_pkg_mgr == 'apt'
 
-- name: 'Update yum package cache'
-  yum: update_cache=yes state=present
-  when: ansible_pkg_mgr == 'yum'
+- name: 'Fix dnf ansible/issues/14427'
+  shell: dnf install -y python-dnf
+  when: ansible_pkg_mgr == 'dnf'
 
 - include_vars: "{{ item }}"
   with_first_found:
@@ -47,4 +47,4 @@
   shell: python setup.py install
   args:
     chdir: "{{ duplicity_workspace }}/duplicity-{{ duplicity_version }}"
-    creates: /usr/local/bin/duplicity
+    creates: "{{ duplicity_bin }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -4,12 +4,22 @@
   apt:
     update_cache: yes
     cache_valid_time: 86400
+  when: ansible_pkg_mgr == 'apt'
 
-- name: 'Install dependencies'
-  apt:
+- name: 'Update yum package cache'
+  yum: update_cache=yes state=present
+  when: ansible_pkg_mgr == 'yum'
+
+- include_vars: "{{ item }}"
+  with_first_found:
+   - "{{ansible_os_family}}.yml"
+   - "{{ansible_pkg_mgr}}.yml"
+
+- name: 'Install pkg dependencies'
+  package:
     pkg: "{{ item }}"
     state: present
-  with_items: '{{duplicity_apt_dependencies}}'
+  with_items: '{{duplicity_pkg_dependencies}}'
 
 - name: 'Install pip packages'
   pip:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,16 +1,16 @@
 ---
 - name: 'Get current version'
   shell: duplicity --version
-  register: current_duplicity_version
+  register: '{{current_duplicity_version}}'
   ignore_errors: true
   changed_when: false
 
 - set_fact:
     current_duplicity_version: "{% if current_duplicity_version.stdout is defined %}{{ current_duplicity_version.stdout | replace('duplicity ', '') }}{% endif %}"
-#- debug: var=current_duplicity_version
+#- debug: var='{{current_duplicity_version}}'
 
 - include: install.yml
-  when: current_duplicity_version is not defined or duplicity_version is not defined or current_duplicity_version != duplicity_version
+  when: '{{current_duplicity_version is not defined or duplicity_version is not defined or current_duplicity_version != duplicity_version}}'
   tags: ['duplicity-install']
 
 - include: gpg.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 - name: 'Get current version'
-  shell: duplicity --version
+  shell: duplicity --version | cut -f2 -d ' '
   register: current_duplicity_version
   ignore_errors: true
   changed_when: false
 
 - set_fact:
-    current_duplicity_version: "{% if current_duplicity_version.stdout is defined %}{{ current_duplicity_version.stdout | replace('duplicity ', '') }}{% endif %}"
+    current_duplicity_version: '{{current_duplicity_version.stdout}}'
 #- debug: var='{{current_duplicity_version}}'
 
 - include: install.yml
@@ -19,3 +19,11 @@
 
 - include: configure.yml
   tags: ['duplicity-configure']
+
+- name: 'Check existing duplicity version'
+  shell: duplicity --version | cut -f2 -d ' '
+  register: final_duplicity_version
+  ignore_errors: true
+
+- fail: msg="Fail if existing duplicity version '{{final_duplicity_version.stdout}}' not = '{{duplicity_version}}'"
+  when: final_duplicity_version.stdout != duplicity_version

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: 'Get current version'
   shell: duplicity --version
-  register: '{{current_duplicity_version}}'
+  register: current_duplicity_version
   ignore_errors: true
   changed_when: false
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,6 +13,10 @@
   when: current_duplicity_version is not defined or duplicity_version is not defined or current_duplicity_version != duplicity_version
   tags: ['duplicity-install']
 
+- include: build.yml
+  when: duplicity_install_type == "build"
+  tags: ['duplicity-install']
+
 - include: gpg.yml
   when: duplicity_gpg_public_keys|length or duplicity_gpg_private_keys|length or duplicity_gpg_ownertrusts|length
   tags: ['duplicity-gpg']

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,6 +28,7 @@
   shell: duplicity --version | cut -f2 -d ' '
   register: final_duplicity_version
   ignore_errors: true
+  changed_when: false
 
 - fail: msg="Fail if existing duplicity version '{{final_duplicity_version.stdout}}' not = '{{duplicity_version}}'"
   when: final_duplicity_version.stdout != duplicity_version

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,7 @@
 
 - set_fact:
     current_duplicity_version: "{% if current_duplicity_version.stdout is defined %}{{ current_duplicity_version.stdout | replace('duplicity ', '') }}{% endif %}"
-- debug: var=current_duplicity_version
+#- debug: var=current_duplicity_version
 
 - include: install.yml
   when: current_duplicity_version is not defined or duplicity_version is not defined or current_duplicity_version != duplicity_version

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,11 +10,11 @@
 #- debug: var='{{current_duplicity_version}}'
 
 - include: install.yml
-  when: '{{current_duplicity_version is not defined or duplicity_version is not defined or current_duplicity_version != duplicity_version}}'
+  when: current_duplicity_version is not defined or duplicity_version is not defined or current_duplicity_version != duplicity_version
   tags: ['duplicity-install']
 
 - include: gpg.yml
-  when: "{{ duplicity_gpg_public_keys|length or duplicity_gpg_private_keys|length or duplicity_gpg_ownertrusts|length }}"
+  when: duplicity_gpg_public_keys|length or duplicity_gpg_private_keys|length or duplicity_gpg_ownertrusts|length
   tags: ['duplicity-gpg']
 
 - include: configure.yml

--- a/tests/test-gpg.yml
+++ b/tests/test-gpg.yml
@@ -1,6 +1,6 @@
 ---
 - hosts: localhost
-  remote_user: root
+  become: yes
 
   vars:
     duplicity_gpg_public_keys:

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -3,6 +3,7 @@
   remote_user: root
 
   vars:
+    duplicity_version: 0.6.23
     duplicity_known_hosts:
       - host: 'localhost'
         key: 'localhost ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJ8pPoZomzmnGWI4I0qV3GGPcxE72uKHunwOWAq11F6uE+pEVgLrEIA/jmzViSxQHrZ7QomvRHba9DNwTsTz89w='

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -3,6 +3,11 @@
   remote_user: root
 
   vars:
+    duplicity_known_hosts:
+      - host: 'localhost'
+        key: 'localhost ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJ8pPoZomzmnGWI4I0qV3GGPcxE72uKHunwOWAq11F6uE+pEVgLrEIA/jmzViSxQHrZ7QomvRHba9DNwTsTz89w='
+        state: present
+
     duplicity_config_vars:
       SERVER: 'file:///tmp/duplicity-backup/'
       DEFAULT_PARAMS: '--verbosity info --exclude-device-files --exclude-other-filesystems --exclude-if-present .duplicity-ignore'

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,6 +1,6 @@
 ---
 - hosts: localhost
-  remote_user: root
+  become: yes
 
   vars:
     duplicity_version: 0.6.23

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,6 +1,14 @@
 ---
 duplicity_pkg_dependencies:
   - python-boto
+  - python-lockfile
+  - python-paramiko
+  - python-pip
+  - mailx
+  - duplicity
+
+duplicity_build_dependencies:
+  - python-boto
   - python-devel
   - python-lockfile
   - python-paramiko

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,15 @@
+---
+duplicity_pkg_dependencies:
+  - python-boto
+  - python-dev
+  - python-lockfile
+  - python-paramiko
+  - python-pip
+  - python-setuptools
+  - python-pycryptopp
+  - gnupg2
+  - ncftp
+  - lftp
+  - librsync-dev
+  - mailutils
+  - build-essential

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,15 +1,19 @@
 ---
 duplicity_pkg_dependencies:
   - python-boto
-  - python-dev
+  - python-devel
   - python-lockfile
   - python-paramiko
   - python-pip
   - python-setuptools
-  - python-pycryptopp
+  - redhat-rpm-config
+  - cryptopp
   - gnupg2
   - ncftp
   - lftp
-  - librsync-dev
-  - mailutils
-  - build-essential
+  - librsync-devel
+  - libselinux-python
+  - mailx
+  - gcc
+
+duplicity_bin: /usr/bin/duplicity

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,6 +1,7 @@
 ---
 duplicity_pkg_dependencies:
   - python-boto
+  - python-devel
   - python-lockfile
   - python-paramiko
   - python-pip

--- a/vars/apt.yml
+++ b/vars/apt.yml
@@ -1,0 +1,15 @@
+---
+duplicity_pkg_dependencies:
+  - python-boto
+  - python-dev
+  - python-lockfile
+  - python-paramiko
+  - python-pip
+  - python-setuptools
+  - python-pycryptopp
+  - gnupg2
+  - ncftp
+  - lftp
+  - librsync-dev
+  - mailutils
+  - build-essential

--- a/vars/apt.yml
+++ b/vars/apt.yml
@@ -13,3 +13,5 @@ duplicity_pkg_dependencies:
   - librsync-dev
   - mailutils
   - build-essential
+
+duplicity_bin: /usr/local/bin/duplicity

--- a/vars/apt.yml
+++ b/vars/apt.yml
@@ -1,6 +1,14 @@
 ---
 duplicity_pkg_dependencies:
   - python-boto
+  - python-lockfile
+  - python-paramiko
+  - python-pip
+  - mailutils
+  - duplicity
+
+duplicity_build_dependencies:
+  - python-boto
   - python-dev
   - python-lockfile
   - python-paramiko

--- a/vars/apt.yml
+++ b/vars/apt.yml
@@ -1,6 +1,7 @@
 ---
 duplicity_pkg_dependencies:
   - python-boto
+  - python-dev
   - python-lockfile
   - python-paramiko
   - python-pip

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -8,6 +8,7 @@ duplicity_apt_dependencies:
   - python-lockfile
   - python-paramiko
   - python-pip
+  - python-setuptools
   - python-pycryptopp
   - gnupg2
   - ncftp

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,20 +2,6 @@
 # vars file for ansible-role-duplicity
 duplicity_download_url: "https://code.launchpad.net/duplicity/0.7-series/{{ duplicity_version }}/+download/duplicity-{{ duplicity_version }}.tar.gz"
 duplicity_workspace: '/opt'
-duplicity_apt_dependencies:
-  - python-boto
-  - python-dev
-  - python-lockfile
-  - python-paramiko
-  - python-pip
-  - python-setuptools
-  - python-pycryptopp
-  - gnupg2
-  - ncftp
-  - lftp
-  - librsync-dev
-  - mailutils
-  - build-essential
 
 duplicity_pip_packages:
   - { name: pip, state: latest }


### PR DESCRIPTION
Hello, i'm make role more flexible, build or pkg install (pkg by default), RH support (CentOS and Fedora tested).
Make optional install custom .sh and shell (not install by default).

Remove support Ansible < 2.0 (used module package)

Sorry travis spam, my first time use this.
